### PR TITLE
Prevent XSS attack when using class String instead of native string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ class ReactIntlUniversal {
       for (let i in variables) {
         let value = variables[i];
         if (
-          typeof value === "string" &&
+          (typeof value === "string" || value instanceof String) &&
           value.indexOf("<") >= 0 &&
           value.indexOf(">") >= 0
         ) {


### PR DESCRIPTION
This PR adds an additional check to make sure that the passed variable is not an instance of the `String` wrapper class. Previously this check only checked for native string, e.g. `typeof var === "string"` which will fail for `String` since `typeof new String('blah') === "object"`, thus an XSS attack was possible.