### PR TITLE
Add support for fallback locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ require('intl/locale-data/jsonp/ja.js');
    * @param {Object} options.locales App locale data like {"en-US":{"key1":"value1"},"zh-CN":{"key1":"值1"}}
    * @param {Object} options.commonLocaleDataUrls Custom common locale urls. See https://github.com/alibaba/react-intl-universal/releases/tag/1.12.0
    * @param {Object} options.warningHandler Ability to accumulate missing messages using third party services. See https://github.com/alibaba/react-intl-universal/releases/tag/1.11.1
+   * @param {string} options.fallbackLocale One locale from options.locales to use if a key is not found in the current locale
    * @returns {Promise}
    */
   init(options)

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ class ReactIntlUniversal {
       locales: {}, // app locale data like {"en-US":{"key1":"value1"},"zh-CN":{"key1":"值1"}}
       warningHandler: console.warn, // ability to accumulate missing messages using third party services like Sentry
       commonLocaleDataUrls: COMMON_LOCALE_DATA_URLS,
+      fallbackLocale: '', // Locale to use if a key is not found in the current locale
     };
   }
 
@@ -68,10 +69,20 @@ class ReactIntlUniversal {
     }
     let msg = this.getDescendantProp(locales[currentLocale], key);
     if (msg == null) {
-      this.options.warningHandler(
-        `react-intl-universal key "${key}" not defined in ${currentLocale}`
-      );
-      return "";
+      if (this.options.fallbackLocale) {
+        msg = this.getDescendantProp(locales[this.options.fallbackLocale], key);
+        if (msg === null) {
+          this.options.warningHandler(
+            `react-intl-universal key "${key}" not defined in ${currentLocale} or the fallback locale, ${this.options.fallbackLocale}`
+          );
+          return "";
+        }
+      } else {
+        this.options.warningHandler(
+          `react-intl-universal key "${key}" not defined in ${currentLocale}`
+        );
+        return "";
+      }
     }
     if (variables) {
       variables = Object.assign({}, variables);

--- a/test/index.js
+++ b/test/index.js
@@ -284,3 +284,8 @@ test("load mutiple locale data without overriding existing one", () => {
   expect(intl.get("SIMPLE")).toBe("Simple");
   expect(intl.get("MORE")).toBe("More data");
 });
+
+test("Uses fallback locale if key not found", () => {
+  intl.init({ locales, currentLocale: "zh-CN", fallbackLocale: "en-US" });
+  expect(intl.get("ONLY_IN_ENGLISH")).toBe("ONLY_IN_ENGLISH");
+});

--- a/test/locales/en-US.js
+++ b/test/locales/en-US.js
@@ -15,4 +15,5 @@ module.exports = ({
   "DOT.HELLO": "Hello World",
   "BRACE1": "The format is {var}",
   "BRACE2": "The format is ${var}",
+  "ONLY_IN_ENGLISH": "ONLY_IN_ENGLISH"
 });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -70,6 +70,7 @@ declare module "react-intl-universal" {
      * @param {string} options.currentLocale Current locale such as 'en-US'
      * @param {Object} options.locales App locale data like {"en-US":{"key1":"value1"},"zh-CN":{"key1":"值1"}}
      * @param {Object} options.warningHandler Ability to accumulate missing messages using third party services like Sentry
+     * @param {string} options.fallbackLocale One locale from options.locales to use if a key is not found in the current locale
      * @returns {Promise}
      */
     export function init(options: ReactIntlUniversalOptions): Promise<void>;


### PR DESCRIPTION
We ran into a situation where we had locale information for one locale but not the other. We would like to be able to specify a default locale to fall back to if a key is not found in the current locale. This PR adds such an option as `fallbackLocale`. This is particularly useful from a dev perspective since the dominant language of the devs will almost always have all the strings.