### PR TITLE
fix console.warn bug in some android native browsers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ class ReactIntlUniversal {
       urlLocaleKey: null, // URL's query Key to determine locale. Example: if URL=http://localhost?lang=en-US, then set it 'lang'
       cookieLocaleKey: null, // Cookie's Key to determine locale. Example: if cookie=lang:en-US, then set it 'lang'
       locales: {}, // app locale data like {"en-US":{"key1":"value1"},"zh-CN":{"key1":"值1"}}
-      warningHandler: console.warn, // ability to accumulate missing messages using third party services like Sentry
+      warningHandler: console.warn.bind(console), // ability to accumulate missing messages using third party services like Sentry
       escapeHtml: true, // disable escape html in variable mode
       commonLocaleDataUrls: COMMON_LOCALE_DATA_URLS,
       fallbackLocale: null, // Locale to use if a key is not found in the current locale
@@ -103,7 +103,7 @@ class ReactIntlUniversal {
     }
 
     try {
-      const msgFormatter = new IntlMessageFormat(msg, currentLocale, formats); 
+      const msgFormatter = new IntlMessageFormat(msg, currentLocale, formats);
       return msgFormatter.format(variables);
     } catch (err) {
       this.options.warningHandler(


### PR DESCRIPTION
Change-Id: I0df3a05c0bb1b3bb40a7bb5afaa967ec4dc57ec2
```
const x = console.log
x('hello')
```
will break in some android native browsers
https://www.reddit.com/r/javascript/comments/3a9buu/javascript_uncaught_typeerror_illegal_invocation/