### PR TITLE
update intl-messageformat to support ICU Number skeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cookie": "^0.3.1",
     "escape-html": "^1.0.3",
     "intl": "^1.2.5",
-    "intl-messageformat": "^2.2.0",
+    "intl-messageformat": "^7.8.4",
     "invariant": "^2.2.2",
     "lodash.merge": "^4.6.1",
     "object-keys": "^1.0.11",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -206,6 +206,39 @@ test("Message with plural", () => {
   ).toBe("你有1张照片");
 });
 
+test("Message with skeleton", () => {
+  intl.init({ locales, currentLocale: "en-US" });
+  expect(
+    intl.get("SKELETON_VAR", {
+      value: 42.5
+    })
+  ).toBe("Increase by 42.5");
+
+  expect(
+    intl.get("SKELETON_VAR", {
+      value: 42
+    })
+  ).toBe("Increase by 42.0");
+
+  expect(
+    intl.get("SKELETON_VAR", {
+      value: 42.109
+    })
+  ).toBe("Increase by 42.11");
+
+  expect(
+    intl.get("SKELETON_SELECTORDINAL", {
+      year: 2
+    })
+  ).toBe("It's my cat's 2nd birthday!");
+
+  expect(
+    intl.get("SKELETON_SELECTORDINAL", {
+      year: 10
+    })
+  ).toBe("It's my cat's 10th birthday!");
+})
+
 test("Without default message, just return empty string", () => {
   intl.init({ locales, currentLocale: "en-US" });
   expect(intl.get("not-exist-key")).toBe("");

--- a/test/locales/en-US.js
+++ b/test/locales/en-US.js
@@ -15,5 +15,7 @@ module.exports = ({
   "DOT.HELLO": "Hello World",
   "BRACE1": "The format is {var}",
   "BRACE2": "The format is ${var}",
-  "ONLY_IN_ENGLISH": "ONLY_IN_ENGLISH"
+  "ONLY_IN_ENGLISH": "ONLY_IN_ENGLISH",
+  "SKELETON_VAR": "Increase by {value, number, ::.0#}",
+  "SKELETON_SELECTORDINAL": "It's my cat's {year, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} birthday!"
 });


### PR DESCRIPTION
Updating intl-messageformat would allow [ICU Number skeletons](https://github.com/unicode-org/icu/blob/master/docs/userguide/format_parse/numbers/skeletons.md), which enables advanced formatting like:
```
{meters, number, :: measure-unit/length-meter unit-width-full-name} => 1,000 metres
{value, number, :: percent .00} => 90.00%
```
[intl-messageformat@8](https://github.com/formatjs/formatjs/blob/7bfc5c085b13915be7b95d0a9e2284167faa6375/packages/intl-messageformat/CHANGELOG.md#800-2020-03-04) changes the way embedded HTML works and would require more changes.