### PR TITLE
Default to translation key if not found in locale json

### DIFF
--- a/src/ReactIntlUniversal.js
+++ b/src/ReactIntlUniversal.js
@@ -42,11 +42,12 @@ class ReactIntlUniversal {
     invariant(key, "key is required");
     const { locales, currentLocale, formats } = this.options;
 
+    const id = String(key);
     if (!locales || !locales[currentLocale]) {
       this.options.warningHandler(
         `react-intl-universal locales data "${currentLocale}" not exists.`
       );
-      return "";
+      return id;
     }
     let msg = this.getDescendantProp(locales[currentLocale], key);
     if (msg == null) {
@@ -56,13 +57,13 @@ class ReactIntlUniversal {
           this.options.warningHandler(
             `react-intl-universal key "${key}" not defined in ${currentLocale} or the fallback locale, ${this.options.fallbackLocale}`
           );
-          return "";
+          return id;
         }
       } else {
         this.options.warningHandler(
           `react-intl-universal key "${key}" not defined in ${currentLocale}`
         );
-        return "";
+        return id;
       }
     }
     if (variables) {


### PR DESCRIPTION
Mirror behavior of `react-intl` when key requested is not found in locale json.
https://github.com/alibaba/react-intl-universal/issues/141