### PR TITLE
fix key for Chinese

### DIFF
--- a/packages/react-intl-universal-extract/src/extract/index.test.js
+++ b/packages/react-intl-universal-extract/src/extract/index.test.js
@@ -25,8 +25,8 @@ test("Test extract", () => {
   expect(getOriginal(result, 'basic3')).toBe('Default message for basic(3)');
   expect(getTransformed(result, 'basic3')).toBe('Default message for basic(3)');
 
-  expect(getOriginal(result, 'basic4')).toBe('Default message for basic(4) with 中文');
-  expect(getTransformed(result, 'basic4')).toBe('Default message for basic(4) with 中文');
+  expect(getOriginal(result, '特征4')).toBe('Default message for basic(4) with 中文');
+  expect(getTransformed(result, '特征4')).toBe('Default message for basic(4) with 中文');
 
   expect(getOriginal(result, 'basic5')).toBe('Default message for basic5 with 中文(5)');
   expect(getTransformed(result, 'basic5')).toBe('Default message for basic5 with 中文(5)');

--- a/packages/react-intl-universal-extract/src/util/constant.js
+++ b/packages/react-intl-universal-extract/src/util/constant.js
@@ -1,5 +1,5 @@
 
-const DETECT_REGEXP = /(intl|IntlUtils)\s*\.\s*(get\s*\(\s*["'`]([\w\.-]+)["'`][\s\S]*?\)\s*\.\s*(defaultMessage|d)\s*\(\s*[`"']([\s\S]+?)[`"']|getHTML*\s*\(\s*["'`]([\w\.-]+)["'`][\s\S]*?\)\s*\.\s*(defaultMessage|d)\s*\(\s*(["'`<][\s\S]+?["'`>]))[\s*,]*\)/gm;
+const DETECT_REGEXP = /(intl|IntlUtils)\s*\.\s*(get\s*\(\s*["'`]([\s\S]+?)["'`][\s\S]*?\)\s*\.\s*(defaultMessage|d)\s*\(\s*[`"']([\s\S]+?)[`"']|getHTML*\s*\(\s*["'`]([\s\S]+?)["'`][\s\S]*?\)\s*\.\s*(defaultMessage|d)\s*\(\s*(["'`<][\s\S]+?["'`>]))[\s*,]*\)/gm;
 
 const NO_DEFAULT_REGEXP = /intl\s*\.\s*get(HTML)*\s*\(\s*["'`]([\w\.-]+)["'`]['"\w\.,{}:\s-]*\)\s*(?!\s*\.\s*(d|defaultMessage)\s*\(\s*[<'"`\s\\]+)/gm;
 

--- a/packages/react-intl-universal-extract/test-files/App.js
+++ b/packages/react-intl-universal-extract/test-files/App.js
@@ -14,7 +14,7 @@ class App extends Component {
         <div>{intl.get('basic1').defaultMessage('default message')}</div>
         <div>{intl.get('basic2').d('Default message for basic[2]')}</div>
         <div>{intl.get('basic3').d('Default message for basic(3)')}</div>
-        <div>{intl.get('basic4').d('Default message for basic(4) with 中文')}</div>
+        <div>{intl.get('特征4').d('Default message for basic(4) with 中文')}</div>
         <div>{intl.get('basic5').d('Default message for basic5 with 中文(5)')}</div>
         <div>{intl.get('basic6').d('Default message for basic6 with "123(中文)"')}</div>
 


### PR DESCRIPTION
Signed-off-by: dehong <dehong@xsky.com>
***📝 变更记录 📝***
- 替换 src/util/constant.js 的` DETECT_REGEXP`，以此提供 `get` 和 `getHtml` 可以输入 中文 key
- `([\w\.-]+) ` ->` ([\s\S]+?)`
  -- 如：intl.get('我的收藏').d('我的收藏') ，在react-intl-universal-extract 提取的时候，可以使用中文key
  
  zhCN.json
  
  {
    ‘我的收藏'：‘我的收藏'’
  }