### PR TITLE
add defaultVariables options to initialize properties

### DIFF
--- a/packages/react-intl-universal/src/ReactIntlUniversal.js
+++ b/packages/react-intl-universal/src/ReactIntlUniversal.js
@@ -22,6 +22,7 @@ class ReactIntlUniversal {
       escapeHtml: true, // disable escape html in variable mode
       // commonLocaleDataUrls: COMMON_LOCALE_DATA_URLS,
       fallbackLocale: null, // Locale to use if a key is not found in the current locale
+      defaultVariables: {} // Default variables in message
     };
   }
 
@@ -31,7 +32,7 @@ class ReactIntlUniversal {
    * @param {Object} variables Variables in message
    * @returns {string} message
    */
-  get(key, variables) {
+  get(key, variables = this.options.defaultVariables) {
     if (this.options.intlGetHook) {
       try {
         this.options.intlGetHook(key, this.options.currentLocale);

--- a/packages/react-intl-universal/typings/index.d.ts
+++ b/packages/react-intl-universal/typings/index.d.ts
@@ -93,6 +93,7 @@ declare module "react-intl-universal" {
         localStorageLocaleKey?: string;
         warningHandler?: (message?: any, error?: any) => void;
         escapeHtml?: boolean;
+        defaultVariables?: { [key: string]: any }
     }
     
     export interface ReactIntlUniversalMessageDescriptor {


### PR DESCRIPTION
In my project, there will be a lot of the same local app data variabls:
e.g
`{
"a": "Hello,{appName}",
"b": "Hi,{appName}",
"c": "Good well,{appName}",
...
}`

JS code

`
// file1
Intl.get('a',{appName:'wahaha'});
// file2
Intl.get('b',{appName:'wahaha'});
// file3
Intl.get('c',{appName:'wahaha'});
`


I want to use a default variables to avoid generating a lot of duplicate code
