### PR TITLE
feat: support ECMAScript module format

### DIFF
--- a/packages/react-intl-universal/.gitignore
+++ b/packages/react-intl-universal/.gitignore
@@ -1,4 +1,4 @@
-dist/
+es/
 lib/
 coverage/
 node_modules/

--- a/packages/react-intl-universal/package.json
+++ b/packages/react-intl-universal/package.json
@@ -16,6 +16,12 @@
     "icu"
   ],
   "main": "./lib/index.js",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js"
+    }
+  },
   "scripts": {
     "test": "jest --coverage",
     "test:watch": "jest --watch --verbose --coverage",

--- a/packages/react-intl-universal/rollup.config.js
+++ b/packages/react-intl-universal/rollup.config.js
@@ -15,6 +15,10 @@ export default {
         {
             dest: 'lib/index.js',
             format: 'cjs'
+        },
+        {
+            dest: 'es/index.js',
+            format: 'es'
         }
     ],
     banner : copyright,

--- a/packages/react-intl-universal/src/ReactIntlUniversal.js
+++ b/packages/react-intl-universal/src/ReactIntlUniversal.js
@@ -1,4 +1,4 @@
-import IntlPolyfill from "intl";
+import "intl";
 import React from "react";
 import IntlMessageFormat from "intl-messageformat";
 import escapeHtml from "escape-html";

--- a/packages/react-intl-universal/src/index.js
+++ b/packages/react-intl-universal/src/index.js
@@ -1,5 +1,5 @@
 import ReactIntlUniversal from './ReactIntlUniversal';
 
-module.exports = new ReactIntlUniversal();
-module.exports.ReactIntlUniversal = ReactIntlUniversal;
-
+const defaultInstance = new ReactIntlUniversal();
+defaultInstance.ReactIntlUniversal = ReactIntlUniversal
+export default defaultInstance;


### PR DESCRIPTION
1. support ECMAScript module format
- rewrite module export from `commonjs` to `esm`
- a new `es` target in rollup.config.js
- tell the consumer where to find the entry point of package, with `exports` field in package.json. This feature added from v12.16.0, see more [details](https://nodejs.org/dist/latest-v16.x/docs/api/packages.html#conditional-exports).

2. fix warnings at build phase
- use more clean style of importing effects, like `import "@babel/polyfill"`
