### PR TITLE
fix: `importStar` or `importDefault` will both work

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,15 @@ Note that you are not necessary to load all locale data, just load the current l
 ```js
 import intl from 'react-intl-universal';
 // common locale data
-require('intl/locale-data/jsonp/en.js');
-require('intl/locale-data/jsonp/zh.js');
+import 'intl/locale-data/jsonp/en.js';
+import 'intl/locale-data/jsonp/zh.js';
+import enUS from './locales/en-US.js';
+import zhCN from './locales/zh-CN.js';
 
 // app locale data
 const locales = {
-  "en-US": require('./locales/en-US.js'),
-  "zh-CN": require('./locales/zh-CN.js'),
+  "en-US": enUS,
+  "zh-CN": zhCN
 };
 
 class App extends Component {

--- a/packages/react-intl-universal/src/index.js
+++ b/packages/react-intl-universal/src/index.js
@@ -3,6 +3,35 @@ import ReactIntlUniversal from './ReactIntlUniversal';
 const defaultInstance = new ReactIntlUniversal();
 // resolved by CommonJS module loader
 defaultInstance.ReactIntlUniversal = ReactIntlUniversal;
-export default defaultInstance;
+// react pattern: https://github.com/facebook/react/blob/main/packages/react/src/React.js
+const get = defaultInstance.get.bind(defaultInstance);
+const getHTML = defaultInstance.getHTML.bind(defaultInstance);
+const formatMessage = defaultInstance.formatMessage.bind(defaultInstance);
+const formatHTMLMessage = defaultInstance.formatHTMLMessage.bind(defaultInstance);
+const determineLocale = defaultInstance.determineLocale.bind(defaultInstance);
+const init = defaultInstance.init.bind(defaultInstance);
+const getInitOptions = defaultInstance.getInitOptions.bind(defaultInstance);
+const load = defaultInstance.load.bind(defaultInstance);
+const getLocaleFromCookie = defaultInstance.getLocaleFromCookie.bind(defaultInstance);
+const getLocaleFromLocalStorage = defaultInstance.getLocaleFromLocalStorage.bind(defaultInstance);
+const getLocaleFromURL = defaultInstance.getLocaleFromURL.bind(defaultInstance);
+const getDescendantProp = defaultInstance.getDescendantProp.bind(defaultInstance);
+const getLocaleFromBrowser = defaultInstance.getLocaleFromBrowser.bind(defaultInstance);
 // resolved by ECMAScript module loader
-export { ReactIntlUniversal };
+export {
+  ReactIntlUniversal,
+  get,
+  getHTML,
+  formatMessage,
+  formatHTMLMessage,
+  determineLocale,
+  init,
+  getInitOptions,
+  load,
+  getLocaleFromCookie,
+  getLocaleFromLocalStorage,
+  getLocaleFromURL,
+  getDescendantProp,
+  getLocaleFromBrowser,
+  defaultInstance as default
+};


### PR DESCRIPTION
There are plenty of developers who use old fashioned style to import this library, which is not totally compatible with ECMAScript Module System. Just like React,  which is a pure CommonJS library too.

'importStar' or 'importDefault' will both work in any bundler with CommonJS Module System and ECMAScript Module System, for example vite, esbuild, webpack, or some frameworks on them, just like rollup, umijs, parcel and so on.
```ts
import * as React from 'react';

// or

import React from 'react';
```

So does this pr do.

```ts
import * as intl from 'react-intl-universal';

// or

import intl from 'react-intl-universal';
```

and optimize grammar of best practice in README.md