### PR TITLE
fix: Improve type hints

### DIFF
--- a/packages/react-intl-universal/typings/index.d.ts
+++ b/packages/react-intl-universal/typings/index.d.ts
@@ -99,6 +99,19 @@ declare module "react-intl-universal" {
         id: string,
         defaultMessage?: string,
     }
+    
+    const intl: {
+      determineLocale: typeof determineLocale;
+      formatHTMLMessage: typeof formatHTMLMessage;
+      formatMessage: typeof formatMessage;
+      get: typeof get;
+      getHTML: typeof getHTML;
+      getInitOptions: typeof getInitOptions;
+      init: typeof init;
+      load: typeof load;
+    };
+
+    export default intl;
 }
 
 declare interface String {


### PR DESCRIPTION
# Pull Request Template

## Description

When entering "intl", there is no type prompt.

Fixes # [(intl type hints)](https://github.com/alibaba/react-intl-universal/issues/226)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

