### PR TITLE
fix: link types in package.json exports

### DIFF
--- a/packages/react-intl-universal/package.json
+++ b/packages/react-intl-universal/package.json
@@ -19,7 +19,8 @@
   "exports": {
     ".": {
       "import": "./es/index.js",
-      "require": "./lib/index.js"
+      "require": "./lib/index.js",
+      "types": "./typings/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
# Pull Request Template

## Description

Fix Typescript `moduleResolution` `Bundler` error in combination with `strict` true.

Fixes #236 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- checkout repo that reproduces the error: https://github.com/NicoVogel/react-intl-universal-module-resolution-bundler
- install packages
- change the package.json from `react-intl-universal` in `node_modules` to include the `types` entry in the package.json `exports` declaration.
- see that the error is gone.
