### PR TITLE
feat: add debug mode

### DIFF
--- a/packages/react-intl-universal/test/index.test.js
+++ b/packages/react-intl-universal/test/index.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import cookie from "cookie";
-import intl from "../src/index";
+import intl, { ReactIntlUniversal } from "../src/index";
 import zhCN from "./locales/zh-CN";
 import enUS from "./locales/en-US";
 import enUSMore from "./locales/en-US-more";
@@ -367,4 +367,31 @@ test("Resolve directly if the environment is not browser", async () => {
     value: createElement,
   });
   expect(result).toBe(undefined);
+});
+
+describe("Test for debug mode", () => {
+  let innerIntl;
+  beforeEach(() => {
+    innerIntl = new ReactIntlUniversal();
+  });
+  test("should output key by using get method if debug mode is true", () => {
+    innerIntl.init({ locales, currentLocale: "zh-CN", debug: true });
+    expect(innerIntl.get("SIMPLE").props.alt).toBe("SIMPLE");
+  });
+  test("should output string by using get method if debug mode is false", () => {
+    innerIntl.init({ locales, currentLocale: "zh-CN", debug: false });
+    expect(innerIntl.get("SIMPLE")).toBe("简单");
+  });
+  test("should output key by using getHTML method if debug mode is true", () => {
+    innerIntl.init({ locales, currentLocale: "zh-CN", debug: true });
+    expect(innerIntl.getHTML("TIP").props.alt).toBe("TIP");
+  });
+  test("should return original DOM without key by using getHTML method if debug mode is false", () => {
+    innerIntl.init({ locales, currentLocale: "zh-CN", debug: false });
+    expect(innerIntl.getHTML("TIP").props.alt).toBeUndefined();
+  });
+  test("should has defaultMessage method in after get calling", () => {
+    innerIntl.init({ locales, currentLocale: "zh-CN", debug: true });
+    expect(innerIntl.get("TIP").d).not.toBeUndefined();
+  });
 });

--- a/packages/react-intl-universal/typings/index.d.ts
+++ b/packages/react-intl-universal/typings/index.d.ts
@@ -60,7 +60,7 @@ declare module "react-intl-universal" {
     export function getHTML(key: string, value: any): string;
 
     /**
-     * Get the inital options 
+     * Get the inital options
      * @returns {Object} options includes currentLocale and locales
      */
     export function getInitOptions(): ReactIntlUniversalOptions;
@@ -79,7 +79,7 @@ declare module "react-intl-universal" {
 
     /**
      * Load more locales after init
-     * @param {Object} locales App locale data 
+     * @param {Object} locales App locale data
      */
     export function load(locales: { [key: string]: any }): void;
 
@@ -93,13 +93,14 @@ declare module "react-intl-universal" {
         localStorageLocaleKey?: string;
         warningHandler?: (message?: any, error?: any) => void;
         escapeHtml?: boolean;
+        debug?: boolean;
     }
-    
+
     export interface ReactIntlUniversalMessageDescriptor {
         id: string,
         defaultMessage?: string,
     }
-    
+
     const intl: {
       determineLocale: typeof determineLocale;
       formatHTMLMessage: typeof formatHTMLMessage;


### PR DESCRIPTION
# Add Debug Mode

## Description

In some reasons, I need to output locale key to UI. This pr added a debug mode. If the option of debug mode is true, the output message would be fold with a span which has an alt key to display locale key.

Fixes #238 

## Type of change

Please delete options that are not relevant.

- [v] New feature (non-breaking change which adds functionality)
- [v] This change requires a documentation update

## How Has This Been Tested?

Test by testing codes

