### PR TITLE
Solve some XSS attack bypass scenarios

### DIFF
--- a/packages/react-intl-universal/src/ReactIntlUniversal.js
+++ b/packages/react-intl-universal/src/ReactIntlUniversal.js
@@ -77,8 +77,7 @@ class ReactIntlUniversal {
         if (
           this.options.escapeHtml === true &&
           (typeof value === "string" || value instanceof String) &&
-          value.indexOf("<") >= 0 &&
-          value.indexOf(">") >= 0
+          value.indexOf("<") >= 0
         ) {
           value = escapeHtml(value);
         }


### PR DESCRIPTION
Solve some XSS attack bypass scenarios

# Pull Request Template

## Description

Fixes # XSS attack

If you use getHTML, some specific attack tags will not be processed because the execution precondition of escapeHtml is that the variable exists “<>” at the same time.

The following tags will not be escaped and the attack script will be executed:
`<img src=x onxss="" onerror="alert(document.cookie);"`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Run unit test.

- Add Test Case: None
