### PR TITLE
Drop deprecated formatter libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - Display numbers, currency, dates and times for different locales.
 - Pluralize labels in strings.
 - Support variables in message.
-- Support HTML in message.
+- Support HTML in message ([read more](#html-message)).
 - Support for 150+ languages.
 - Runs in the browser and Node.js.
 - Message format is strictly implemented by [ICU standards](http://userguide.icu-project.org/formatparse/messages).
@@ -215,6 +215,23 @@ JS code:
 ```js
 intl.getHTML('TIP'); // {React.Element}
 ```
+
+Before using HTML tags inside the messages, you need to define how the HTML/XML tags you intend to use should be parsed, during the library initializing.
+
+Defining the XML parser:
+
+```js
+intl.init({
+  // ...
+  xmlParser: {
+    div: children => '<div>' + children + '</div>',
+    span: children => '<span>' + children + '</span>',
+    // ...
+  }
+})
+```
+
+Use this feature with caution as there are a set of restrictions. [Click here to learn more](https://formatjs.io/docs/intl-messageformat/#rich-text-support).
 
 ### Helper
 [react-intl-universal](https://www.npmjs.com/package/react-intl-universal) provides a utility helping developer determine the user's `currentLocale`. As the running examples, when user select a new locale, it redirect user new location like `http://localhost:3000?lang=en-US`. Then, we can use `intl.determineLocale` to get the locale from URL. It can also support determine user's locale via cookie, localStorage, and browser default language. Refer to the APIs section for more detail.

--- a/packages/react-intl-universal/package-lock.json
+++ b/packages/react-intl-universal/package-lock.json
@@ -1,21 +1,52 @@
 {
   "name": "react-intl-universal",
-  "version": "2.9.0",
+  "version": "2.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@formatjs/intl-unified-numberformat": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.7.tgz",
-      "integrity": "sha512-KnWgLRHzCAgT9eyt3OS34RHoyD7dPDYhRcuKn+/6Kv2knDF8Im43J6vlSW6Hm1w63fNq3ZIT1cFk7RuVO3Psag==",
+    "@formatjs/ecma402-abstract": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.2.tgz",
+      "integrity": "sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==",
       "requires": {
-        "@formatjs/intl-utils": "^2.3.0"
+        "@formatjs/intl-localematcher": "0.5.4",
+        "tslib": "^2.4.0"
       }
     },
-    "@formatjs/intl-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
-      "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
+    "@formatjs/fast-memoize": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.0.tgz",
+      "integrity": "sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@formatjs/icu-messageformat-parser": {
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.6.tgz",
+      "integrity": "sha512-etVau26po9+eewJKYoiBKP6743I1br0/Ie00Pb/S/PtmYfmjTcOn2YCh2yNkSZI12h6Rg+BOgQYborXk46BvkA==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/icu-skeleton-parser": "1.8.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@formatjs/icu-skeleton-parser": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.0.tgz",
+      "integrity": "sha512-QWLAYvM0n8hv7Nq5BEs4LKIjevpVpbGLAJgOaYzg9wABEoX1j0JO1q2/jVkO6CVlq0dbsxZCngS5aXbysYueqA==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.18.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@formatjs/intl-localematcher": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz",
+      "integrity": "sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
     },
     "abab": {
       "version": "1.0.4",
@@ -1979,31 +2010,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "intl": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/intl/-/intl-1.2.5.tgz",
-      "integrity": "sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94="
-    },
-    "intl-format-cache": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.3.1.tgz",
-      "integrity": "sha512-OEUYNA7D06agqPOYhbTkl0T8HA3QKSuwWh1HiClEnpd9vw7N+3XsQt5iZ0GUEchp5CW1fQk/tary+NsbF3yQ1Q=="
-    },
     "intl-messageformat": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-7.8.4.tgz",
-      "integrity": "sha512-yS0cLESCKCYjseCOGXuV4pxJm/buTfyCJ1nzQjryHmSehlptbZbn9fnlk1I9peLopZGGbjj46yHHiTAEZ1qOTA==",
+      "version": "10.5.11",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.11.tgz",
+      "integrity": "sha512-eYq5fkFBVxc7GIFDzpFQkDOZgNayNTQn4Oufe8jw6YY6OHVw70/4pA3FyCsQ0Gb2DnvEJEMmN2tOaXUGByM+kg==",
       "requires": {
-        "intl-format-cache": "^4.2.21",
-        "intl-messageformat-parser": "^3.6.4"
-      }
-    },
-    "intl-messageformat-parser": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-3.6.4.tgz",
-      "integrity": "sha512-RgPGwue0mJtoX2Ax8EmMzJzttxjnva7gx0Q7mKJ4oALrTZvtmCeAw5Msz2PcjW4dtCh/h7vN/8GJCxZO1uv+OA==",
-      "requires": {
-        "@formatjs/intl-unified-numberformat": "^3.2.0"
+        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/fast-memoize": "2.2.0",
+        "@formatjs/icu-messageformat-parser": "2.7.6",
+        "tslib": "^2.4.0"
       }
     },
     "invariant": {
@@ -4617,6 +4632,11 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/packages/react-intl-universal/package-lock.json
+++ b/packages/react-intl-universal/package-lock.json
@@ -93,10 +93,10 @@
         }
       }
     },
-    "@formatjs/intl-unified-numberformat": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.7.tgz",
-      "integrity": "sha512-KnWgLRHzCAgT9eyt3OS34RHoyD7dPDYhRcuKn+/6Kv2knDF8Im43J6vlSW6Hm1w63fNq3ZIT1cFk7RuVO3Psag==",
+    "@formatjs/ecma402-abstract": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.2.tgz",
+      "integrity": "sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==",
       "requires": {
         "@formatjs/intl-localematcher": "0.5.4",
         "tslib": "^2.4.0"
@@ -2544,11 +2544,6 @@
         "hasown": "^2.0.0",
         "side-channel": "^1.0.4"
       }
-    },
-    "intl-format-cache": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.3.1.tgz",
-      "integrity": "sha512-OEUYNA7D06agqPOYhbTkl0T8HA3QKSuwWh1HiClEnpd9vw7N+3XsQt5iZ0GUEchp5CW1fQk/tary+NsbF3yQ1Q=="
     },
     "intl-messageformat": {
       "version": "10.5.11",

--- a/packages/react-intl-universal/package.json
+++ b/packages/react-intl-universal/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "cookie": "^0.3.1",
     "escape-html": "^1.0.3",
-    "intl-messageformat": "^7.8.4",
+    "intl-messageformat": "^10.5.11",
     "invariant": "^2.2.2",
     "lodash.merge": "^4.6.2",
     "object-keys": "^1.0.11",

--- a/packages/react-intl-universal/src/ReactIntlUniversal.js
+++ b/packages/react-intl-universal/src/ReactIntlUniversal.js
@@ -174,10 +174,11 @@ class ReactIntlUniversal {
 
   /**
    * Initialize properties and load CLDR locale data according to currentLocale
-   * @param {Object} options
-   * @param {string} options.currentLocale Current locale such as 'en-US'
-   * @param {any} options.locales App locale data like {"en-US":{"key1":"value1"},"zh-CN":{"key1":"值1"}}
-   * @param {boolean} [options.debug] debug mode
+   * @param {Object} options Initialization options
+   * @param {string} options.currentLocale Current locale (eg. `'en-US'`)
+   * @param {any} options.locales App locale data (eg. `{ "en-US": { "key1": "value1" }, "zh-CN": { "key1": "值1" }}`)
+   * @param {boolean} [options.debug] Enable debug mode
+   * @param {{[tag: string]: (children: any) => string}} [options.xmlParser] Indicates how to parse XML tags inside the messages. (eg. `{ span: children => '<span>' + children + '</span>' }`)
    * @returns {Promise}
    */
   init(options = {}) {

--- a/packages/react-intl-universal/src/ReactIntlUniversal.js
+++ b/packages/react-intl-universal/src/ReactIntlUniversal.js
@@ -21,6 +21,7 @@ class ReactIntlUniversal {
       fallbackLocale: null, // Locale to use if a key is not found in the current locale
       debug: false, // If debugger mode is on, the message will be wrapped by a span
       dataKey: 'data-i18n-key', // If debugger mode is on, the message will be wrapped by a span with this data key
+      xmlParser: { span: chunks => `<span>${chunks}</span>` }, // If there are XML tags present in the message, parsers should be added per tag
     };
   }
 
@@ -39,7 +40,7 @@ class ReactIntlUniversal {
       }
     }
     invariant(key, "key is required");
-    const { locales, currentLocale, formats } = this.options;
+    const { locales, currentLocale, formats, xmlParser } = this.options;
 
     // 1. check if the locale data and key exists
     if (!locales || !locales[currentLocale]) {
@@ -91,7 +92,7 @@ class ReactIntlUniversal {
       let finalMsg;
       if (variables) { // format message with variables
         const msgFormatter = new IntlMessageFormat(msg, currentLocale, formats);
-        finalMsg = msgFormatter.format(variables);
+        finalMsg = msgFormatter.format(Object.assign(xmlParser, variables));
       } else { // no variables, just return the message
         finalMsg = msg;
       }

--- a/packages/react-intl-universal/src/ReactIntlUniversal.js
+++ b/packages/react-intl-universal/src/ReactIntlUniversal.js
@@ -20,7 +20,7 @@ class ReactIntlUniversal {
       fallbackLocale: null, // Locale to use if a key is not found in the current locale
       debug: false, // If debugger mode is on, the message will be wrapped by a span
       dataKey: 'data-i18n-key', // If debugger mode is on, the message will be wrapped by a span with this data key
-      xmlParser: { span: chunks => `<span>${chunks}</span>` }, // If there are XML tags present in the message, parsers should be added per tag
+      xmlParser: { span: children => `<span>${children}</span>` }, // If there are XML tags present in the message, parsers should be added per tag. https://formatjs.io/docs/intl-messageformat/#rich-text-support
     };
   }
 

--- a/packages/react-intl-universal/test/index.test.js
+++ b/packages/react-intl-universal/test/index.test.js
@@ -125,12 +125,19 @@ test("HTML Message with variables and custom XML parser", () => {
 });
 
 test("HTML Message with XSS attack", () => {
-  intl.init({ locales, currentLocale: "en-US" });
+  intl.init({
+    locales,
+    currentLocale: "en-US",
+    xmlParser: {
+      span: children => `<span>${children}</span>`,
+      script: children => `<script>${children}</script>`
+    }
+  });
   let reactEl = intl.getHTML("TIP_VAR", {
-    message: "<sctipt>alert(1)</script>"
+    message: "<script>alert(1)</script>"
   });
   expect(reactEl.props.dangerouslySetInnerHTML.__html).toBe(
-    "This is<span>&lt;sctipt&gt;alert(1)&lt;/script&gt;</span>"
+    "This is<span>&lt;script&gt;alert(1)&lt;/script&gt;</span>"
   );
 });
 

--- a/packages/react-intl-universal/test/index.test.js
+++ b/packages/react-intl-universal/test/index.test.js
@@ -114,6 +114,16 @@ test("HTML Message with variables", () => {
   );
 });
 
+test("HTML Message with variables and custom XML parser", () => {
+  intl.init({ locales, currentLocale: "en-US", xmlParser: { div: children => '<div>' + children + '</div>' } });
+  let reactEl = intl.getHTML("TIP_VAR_DIV", {
+    message: "your message"
+  });
+  expect(reactEl.props.dangerouslySetInnerHTML.__html).toBe(
+    "This is<div>your message</div>"
+  );
+});
+
 test("HTML Message with XSS attack", () => {
   intl.init({ locales, currentLocale: "en-US" });
   let reactEl = intl.getHTML("TIP_VAR", {

--- a/packages/react-intl-universal/test/locales/en-US.js
+++ b/packages/react-intl-universal/test/locales/en-US.js
@@ -3,6 +3,7 @@ module.exports = ({
   "HELLO": "Hello, {name}",
   "TIP": "This is <span>HTML</span>",
   "TIP_VAR": "This is<span>{message}</span>",
+  "TIP_VAR_DIV": "This is<div>{message}</div>",
   "SALE_START": "Sale begins {start, date}",
   "SALE_END": "Sale begins {start, date, long}",
   "COUPON": "Coupon expires at {expires, time, medium}",

--- a/packages/react-intl-universal/typings/index.d.ts
+++ b/packages/react-intl-universal/typings/index.d.ts
@@ -67,6 +67,7 @@ declare module "react-intl-universal" {
      * @param {string} options.fallbackLocale Fallback locale such as 'zh-CN' to use if a key is not found in the current locale
      * @param {boolean} options.escapeHtml To escape html. Default value is true.
      * @param {boolean} options.debug debug mode
+     * @param {Object} options.xmlParser Parser for the XML tags used in messages (eg: `{ span: children => '<span>' + children + '</span>' }`)
      * @returns {Promise}
      */
     export function init(options: ReactIntlUniversalOptions): Promise<void>;
@@ -89,6 +90,7 @@ declare module "react-intl-universal" {
         escapeHtml?: boolean;
         debug?: boolean;
         dataKey?: string;
+        xmlParser?: { [tag: string]: (children: string) => string };
     }
     
     export interface ReactIntlUniversalMessageDescriptor {


### PR DESCRIPTION
## Description

This change updates `intl-messageformat` dependency version so that it fixes following npm deprecation warnings logged when installing `react-intl-universal` in a project.

```
npm WARN deprecated intl-messageformat-parser@3.6.4: We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser
npm WARN deprecated @formatjs/intl-utils@2.3.0: the package is rather renamed to @formatjs/ecma-abstract with some changes in functionality (primarily selectUnit is removed and we don't plan to make any further changes to this package
npm WARN deprecated @formatjs/intl-unified-numberformat@3.3.7: We have renamed the package to @formatjs/intl-numberformat
```

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- Edited Test Case: HTML Message with XSS attack
- Added Test Case: HTML Message with variables and custom XML parser
