### PR TITLE
Add New Internationalization APIs for Enhanced Localization Support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,52 @@ You could make it as [peerDependency](https://github.com/alibaba/react-intl-univ
    * @returns {Object} options includes currentLocale and locales
    */
   getInitOptions()
+
+  /**
+   * Formats a list of React nodes for proper internationalized formatting.
+   * @param {React.ReactNode[]} nodeList - Array of React nodes to format.
+   * @param {Intl.ListFormatOptions} options - Intl.ListFormat options.
+   * @returns {React.ReactNode[]} Array of React nodes formatted with locale-appropriate separators.
+   * 
+   * @example
+   * For en-US locale: formatList(["str1", "str2"]) => Returns: ["str1", ", ", "str2"] => Render as: "str1, str2" in React.js
+   * For zh-CN locale: formatList(["str1", "str2"]) => Returns: ["str1", "、", "str2"] => Render as: "str1、str2" in React.js
+   */
+  formatList(nodeList, options)
+
+  /**
+   * Returns locale-specific parentheses format for the current language.
+   * @param {React.ReactNode} node - The content to be wrapped in parentheses.
+   * @returns {ReactNode[]} An array containing left parenthesis, content, and right parenthesis.
+   * 
+   * @example
+   * For en-US locale: formatParentheses("str1") => Returns ["(", "str1", ")"] => Render as "(str1)" in React.js
+   * For zh-CN locale: formatParentheses("str1") => Returns ["（", "str1", "）"] => Render as "（str1）" in React.js
+   */
+  formatParentheses(node)
+
+  /**
+   * Returns locale-specific colon character for the current language.
+   * @returns {string} The locale-appropriate colon character.
+   * 
+   * @example
+   * For en-US locale: <>{intl.get("LABEL_NAME")}{intl.getColon()}{intl.get("VALUE")}</> => Returns "label: value"
+   * For zh-CN locale: <>{intl.get("LABEL_NAME")}{intl.getColon()}{intl.get("VALUE")}</> => Returns "label：value"
+   */
+  getColon()
+
+  /**
+   * Formats a number according to the current locale.
+   * @param {number} number - The number to format.
+   * @returns {string} The formatted number.
+   * 
+   * @example
+   * For en-US locale: formatNumber(1234.56) => Returns "1,234.56"
+   * For de-DE locale: formatNumber(1234.56) => Returns "1.234,567"
+   * For fr-FR locale: formatNumber(1234.56) => Returns "1 234,567"
+   */
+  formatNumber(number)
+
 ```
 
 

--- a/packages/react-intl-universal/package.json
+++ b/packages/react-intl-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-intl-universal",
-  "version": "2.12.0",
+  "version": "2.13.4",
   "description": "Internationalize React apps. Not only for React component but also for Vanilla JS.",
   "keywords": [
     "intl",

--- a/packages/react-intl-universal/src/ReactIntlUniversal.js
+++ b/packages/react-intl-universal/src/ReactIntlUniversal.js
@@ -327,7 +327,7 @@ class ReactIntlUniversal {
       return number;
     }
     try {
-      return new Intl.NumberFormat(this.options.currentLocale, {}).format(number); // TODO 缓存
+      return new Intl.NumberFormat(this.options.currentLocale, {}).format(number);
     } catch (error) {
       console.error('Error formatting number:', error);
       return number;

--- a/packages/react-intl-universal/src/ReactIntlUniversal.js
+++ b/packages/react-intl-universal/src/ReactIntlUniversal.js
@@ -43,7 +43,7 @@ class ReactIntlUniversal {
     if (!locales || !locales[currentLocale]) {
       let errorMsg = `react-intl-universal locales data "${currentLocale}" not exists.`;
       if (!currentLocale) {
-        errorMsg += ' More info: https://github.com/alibaba/react-intl-universal/issues/144#issuecomment-1345193138'
+        errorMsg += `Check if the key "${key}" is used before it is initialized. More info: https://github.com/alibaba/react-intl-universal/issues/144#issuecomment-1345193138`;
       }
       this.options.warningHandler(errorMsg);
       return "";

--- a/packages/react-intl-universal/src/ReactIntlUniversal.js
+++ b/packages/react-intl-universal/src/ReactIntlUniversal.js
@@ -169,7 +169,7 @@ class ReactIntlUniversal {
       this.getLocaleFromBrowser()
     );
   }
-  
+
   /**
    * Change current locale
    * @param {string} newLocale Current locale such as 'en-US'
@@ -278,6 +278,60 @@ class ReactIntlUniversal {
 
   getLocaleFromBrowser() {
     return navigator.language || navigator.userLanguage;
+  }
+
+  formatList(nodeList, options = { style: 'narrow' }) {
+    if (!Array.isArray(nodeList)) return []
+    if (nodeList.length === 0) return [];
+
+    // Create a mapping from placeholder strings to React nodes
+    const nodeMap = {};
+    const placeholders = nodeList.map((node, index) => {
+      const placeholder = index.toString();
+      nodeMap[placeholder] = node;
+      return placeholder;
+    });
+
+    // Create list formatter with specified locale and options
+    const formatter = new Intl.ListFormat(this.options.currentLocale, options);
+
+    // Get formatted parts (elements, literals like separators/conjunctions)
+    const parts = formatter.formatToParts(placeholders);
+
+    // Transform formatted parts back to React nodes
+    return parts.map(part => {
+      // Element is replaced with original nodes
+      if (part.type === 'element') {
+        return nodeMap[part.value];
+      }
+      // Literal remains as a string
+      return part.value;
+    });
+  }
+
+  formatParentheses(node) {
+    const currentLocale = this.options.currentLocale;
+    const isFullWidth = constants.fullWidthLocales.includes(currentLocale);
+    return isFullWidth ? ['（', node, '）'] : ['(', node, ')'];
+  }
+
+  getColon() {
+    const currentLocale = this.options.currentLocale;
+    const isFullWidth = constants.fullWidthLocales.includes(currentLocale);
+    return isFullWidth ? '：' : ': ';
+  }
+
+  formatNumber(number) {
+    // Return original value if not a number
+    if (typeof number !== 'number' || isNaN(number)) {
+      return number;
+    }
+    try {
+      return new Intl.NumberFormat(this.options.currentLocale, {}).format(number); // TODO 缓存
+    } catch (error) {
+      console.error('Error formatting number:', error);
+      return number;
+    }
   }
 
   _getSpanElementMessage(key, msg) {

--- a/packages/react-intl-universal/src/constants.js
+++ b/packages/react-intl-universal/src/constants.js
@@ -3,7 +3,7 @@
  * Currency code list
  * https://www.currency-iso.org/en/home/tables/table-a1.html
  */
-const currency = ["AFN","EUR","ALL","DZD","USD","AOA","XCD","ARS","AMD","AWG","AUD","AZN","BSD","BHD","BDT","BBD","BYN","BZD","XOF","BMD","INR","BTN","BOB","BOV","BAM","BWP","NOK","BRL","BND","BGN","BIF","CVE","KHR","XAF","CAD","KYD","CLP","CLF","CNY","COP","COU","KMF","CDF","NZD","CRC","HRK","CUP","CUC","ANG","CZK","DKK","DJF","DOP","EGP","SVC","ERN","ETB","FKP","FJD","XPF","GMD","GEL","GHS","GIP","GTQ","GBP","GNF","GYD","HTG","HNL","HKD","HUF","ISK","IDR","XDR","IRR","IQD","ILS","JMD","JPY","JOD","KZT","KES","KPW","KRW","KWD","KGS","LAK","LBP","LSL","ZAR","LRD","LYD","CHF","MOP","MKD","MGA","MWK","MYR","MVR","MRO","MUR","XUA","MXN","MXV","MDL","MNT","MAD","MZN","MMK","NAD","NPR","NIO","NGN","OMR","PKR","PAB","PGK","PYG","PEN","PHP","PLN","QAR","RON","RUB","RWF","SHP","WST","STD","SAR","RSD","SCR","SLL","SGD","XSU","SBD","SOS","SSP","LKR","SDG","SRD","SZL","SEK","CHE","CHW","SYP","TWD","TJS","TZS","THB","TOP","TTD","TND","TRY","TMT","UGX","UAH","AED","USN","UYU","UYI","UZS","VUV","VEF","VND","YER","ZMW","ZWL","XBA","XBB","XBC","XBD","XTS","XXX","XAU","XPD","XPT","XAG"];
+const currency = ["AFN", "EUR", "ALL", "DZD", "USD", "AOA", "XCD", "ARS", "AMD", "AWG", "AUD", "AZN", "BSD", "BHD", "BDT", "BBD", "BYN", "BZD", "XOF", "BMD", "INR", "BTN", "BOB", "BOV", "BAM", "BWP", "NOK", "BRL", "BND", "BGN", "BIF", "CVE", "KHR", "XAF", "CAD", "KYD", "CLP", "CLF", "CNY", "COP", "COU", "KMF", "CDF", "NZD", "CRC", "HRK", "CUP", "CUC", "ANG", "CZK", "DKK", "DJF", "DOP", "EGP", "SVC", "ERN", "ETB", "FKP", "FJD", "XPF", "GMD", "GEL", "GHS", "GIP", "GTQ", "GBP", "GNF", "GYD", "HTG", "HNL", "HKD", "HUF", "ISK", "IDR", "XDR", "IRR", "IQD", "ILS", "JMD", "JPY", "JOD", "KZT", "KES", "KPW", "KRW", "KWD", "KGS", "LAK", "LBP", "LSL", "ZAR", "LRD", "LYD", "CHF", "MOP", "MKD", "MGA", "MWK", "MYR", "MVR", "MRO", "MUR", "XUA", "MXN", "MXV", "MDL", "MNT", "MAD", "MZN", "MMK", "NAD", "NPR", "NIO", "NGN", "OMR", "PKR", "PAB", "PGK", "PYG", "PEN", "PHP", "PLN", "QAR", "RON", "RUB", "RWF", "SHP", "WST", "STD", "SAR", "RSD", "SCR", "SLL", "SGD", "XSU", "SBD", "SOS", "SSP", "LKR", "SDG", "SRD", "SZL", "SEK", "CHE", "CHW", "SYP", "TWD", "TJS", "TZS", "THB", "TOP", "TTD", "TND", "TRY", "TMT", "UGX", "UAH", "AED", "USN", "UYU", "UYI", "UZS", "VUV", "VEF", "VND", "YER", "ZMW", "ZWL", "XBA", "XBB", "XBC", "XBD", "XTS", "XXX", "XAU", "XPD", "XPT", "XAG"];
 
 const numberFormat = {};
 
@@ -17,3 +17,5 @@ for (var i = 0; i < currency.length; i++) {
 export const defaultFormats = {
   number: numberFormat
 }
+
+export const fullWidthLocales = ["zh-CN", "zh-TW", "ko-KR", "ja-JP"];

--- a/packages/react-intl-universal/test/index.test.js
+++ b/packages/react-intl-universal/test/index.test.js
@@ -9,7 +9,7 @@ const dataKey = 'data-i18n-key';
 
 const locales = {
   "en-US": enUS,
-  "zh-CN": zhCN
+  "zh-CN": zhCN,
 };
 
 test("Set specific locale", () => {
@@ -438,5 +438,358 @@ describe("Test for debug mode", () => {
   test("should has defaultMessage method in after get calling", () => {
     innerIntl.init({ locales, currentLocale: "zh-CN", debug: true });
     expect(innerIntl.get("TIP").d).not.toBeUndefined();
+  });
+});
+
+
+describe("Test for formatList", () => {
+  const element = React.createElement("div", { className: 'test' });
+
+  test("formatList should format string array correctly with en-US locale", () => {
+    intl.init({ locales, currentLocale: "en-US" });
+    expect(intl.formatList([
+      "str1",
+      "str2",
+      "str3",
+    ])).toEqual([
+      'str1',
+      ', ',
+      'str2',
+      ', ',
+      'str3',
+    ]);
+  });
+
+  test("formatList should format string array with disjunction type correctly", () => {
+    intl.init({ locales, currentLocale: "en-US" });
+    expect(intl.formatList([
+      "str1",
+      "str2",
+      "str3",
+    ], {
+      type: "disjunction"
+    })).toEqual([
+      'str1',
+      ', ',
+      'str2',
+      ', or ',
+      'str3',
+    ]);
+  });
+
+  test("formatList should format React component array correctly with en-US locale", () => {
+    intl.init({ locales, currentLocale: "en-US" });
+    expect(intl.formatList([
+      "str1",
+      "str2",
+      element,
+    ])).toEqual([
+      "str1",
+      ", ",
+      "str2",
+      ", ",
+      element,
+    ]);
+  });
+
+  test("formatList should format string array correctly with zh-CN locale", () => {
+    intl.init({ locales, currentLocale: "zh-CN" });
+    expect(intl.formatList([
+      "str1",
+      "str2",
+      "str3",
+    ])).toEqual([
+      'str1',
+      '、',
+      'str2',
+      '、',
+      'str3',
+    ]);
+  });
+
+  test("formatList should format React component array correctly with zh-CN locale", () => {
+    intl.init({ locales, currentLocale: "zh-CN" });
+    expect(intl.formatList([
+      "str1",
+      "str2",
+      element,
+    ])).toEqual([
+      "str1",
+      '、',
+      "str2",
+      '、',
+      element,
+    ]);
+  });
+
+  test("formatList should format string array with conjunction type correctly", () => {
+    intl.init({ locales, currentLocale: "en-US" });
+    expect(intl.formatList([
+      "str1",
+      "str2",
+      "str3",
+    ], {
+      type: "conjunction"
+    })).toEqual([
+      'str1',
+      ', ',
+      'str2',
+      ', and ',
+      'str3',
+    ]);
+  });
+
+  test("formatList should format string array with unit type correctly", () => {
+    intl.init({ locales, currentLocale: "en-US" });
+    expect(intl.formatList([
+      "str1",
+      "str2",
+      "str3",
+    ], {
+      type: "unit"
+    })).toEqual([
+      'str1',
+      ', ',
+      'str2',
+      ', ',
+      'str3',
+    ]);
+  });
+
+  test("formatList should format string array with short style correctly", () => {
+    intl.init({ locales, currentLocale: "en-US" });
+    expect(intl.formatList([
+      "str1",
+      "str2",
+      "str3",
+    ], {
+      style: "short"
+    })).toEqual([
+      'str1',
+      ', ',
+      'str2',
+      ', & ',
+      'str3',
+    ]);
+  });
+
+  test("formatList should format string array with narrow style correctly", () => {
+    intl.init({ locales, currentLocale: "en-US" });
+    expect(intl.formatList([
+      "str1",
+      "str2",
+      "str3",
+    ], {
+      style: "narrow"
+    })).toEqual([
+      'str1',
+      ', ',
+      'str2',
+      ', ',
+      'str3',
+    ]);
+  });
+
+  test("formatList should format string array with combination of type and style options", () => {
+    intl.init({ locales, currentLocale: "en-US" });
+    expect(intl.formatList([
+      "str1",
+      "str2",
+      "str3",
+    ], {
+      type: "disjunction",
+      style: "short"
+    })).toEqual([
+      'str1',
+      ', ',
+      'str2',
+      ', or ',
+      'str3',
+    ]);
+  });
+
+  test("formatList should handle empty array correctly", () => {
+    intl.init({ locales, currentLocale: "en-US" });
+    expect(intl.formatList([])).toEqual([]);
+  });
+
+  test("formatList should handle single element array correctly", () => {
+    intl.init({ locales, currentLocale: "en-US" });
+    expect(intl.formatList(["str1"])).toEqual(["str1"]);
+  });
+
+  test("formatList should handle two element array correctly with en-US locale", () => {
+    intl.init({ locales, currentLocale: "en-US" });
+    expect(intl.formatList([
+      "str1",
+      "str2",
+    ])).toEqual([
+      'str1',
+      ', ',
+      'str2',
+    ]);
+  });
+
+  test("formatList should handle two element array correctly with zh-CN locale", () => {
+    intl.init({ locales, currentLocale: "zh-CN" });
+    expect(intl.formatList([
+      "str1",
+      "str2",
+    ])).toEqual([
+      'str1',
+      '、',
+      'str2',
+    ]);
+  });
+
+  test("formatList should handle two element array with disjunction type correctly", () => {
+    intl.init({ locales, currentLocale: "en-US" });
+    expect(intl.formatList([
+      "str1",
+      "str2",
+    ], {
+      type: "disjunction"
+    })).toEqual([
+      'str1',
+      ' or ',
+      'str2',
+    ]);
+  });
+
+  test("formatList should format string array correctly with ja-JP locale", () => {
+    intl.init({ locales, currentLocale: "ja-JP" });
+    expect(intl.formatList([
+      "str1",
+      "str2",
+      "str3",
+    ])).toEqual([
+      'str1',
+      '、',
+      'str2',
+      '、',
+      'str3',
+    ]);
+  });
+
+  test("formatList should format React component array correctly with ja-JP locale", () => {
+    intl.init({ locales, currentLocale: "ja-JP" });
+    expect(intl.formatList([
+      "str1",
+      "str2",
+      element,
+    ])).toEqual([
+      "str1",
+      '、',
+      "str2",
+      '、',
+      element,
+    ]);
+  });
+
+  test("formatList should handle two element array correctly with ja-JP locale", () => {
+    intl.init({ locales, currentLocale: "ja-JP" });
+    expect(intl.formatList([
+      "str1",
+      "str2",
+    ])).toEqual([
+      'str1',
+      '、',
+      'str2',
+    ]);
+  });
+
+});
+
+
+describe("Test for getColon", () => {
+  beforeEach(() => {
+    intl.init({ locales, currentLocale: "en-US" });
+  });
+
+  test("should return half-width colon for non-full-width locales", () => {
+    expect(intl.getColon()).toEqual(": ");
+  });
+
+  test("should return full-width colon for full-width locales", () => {
+    intl.init({ locales, currentLocale: "zh-CN" });
+    expect(intl.getColon()).toEqual("：");
+
+    intl.init({ locales, currentLocale: "ja-JP" });
+    expect(intl.getColon()).toEqual("：");
+
+    intl.init({ locales, currentLocale: "ko-KR" });
+    expect(intl.getColon()).toEqual("：");
+  });
+});
+
+
+describe("Test for formatParentheses", () => {
+  beforeEach(() => {
+    intl.init({ locales, currentLocale: "en-US" });
+  });
+
+  test("should return half-width parentheses for non-full-width locales", () => {
+    expect(intl.formatParentheses("test")).toEqual(["(", "test", ")"]);
+  });
+
+  test("should return full-width parentheses for full-width locales", () => {
+    intl.init({ locales, currentLocale: "zh-CN" });
+    expect(intl.formatParentheses("test")).toEqual(["（", "test", "）"]);
+
+    intl.init({ locales, currentLocale: "ja-JP" });
+    expect(intl.formatParentheses("test")).toEqual(["（", "test", "）"]);
+
+    intl.init({ locales, currentLocale: "ko-KR" });
+    expect(intl.formatParentheses("test")).toEqual(["（", "test", "）"]);
+  });
+
+  test("should handle different input types", () => {
+    expect(intl.formatParentheses("")).toEqual(["(", "", ")"]);
+    expect(intl.formatParentheses(123)).toEqual(["(", 123, ")"]);
+    expect(intl.formatParentheses(null)).toEqual(["(", null, ")"]);
+  });
+});
+
+
+describe("Test for formatNumber", () => {
+
+  test("should format number correctly for en-US locale", () => {
+    intl.init({ locales, currentLocale: "en-US" });
+    expect(intl.formatNumber(1234567)).toBe("1,234,567");
+    expect(intl.formatNumber(1234.567)).toBe("1,234.567");
+    expect(intl.formatNumber(0)).toBe("0");
+  });
+
+  test("should format number correctly for zh-CN locale", () => {
+    intl.init({ locales, currentLocale: "zh-CN" });
+    expect(intl.formatNumber(1234567)).toBe("1,234,567");
+    expect(intl.formatNumber(1234.567)).toBe("1,234.567");
+    expect(intl.formatNumber(0)).toBe("0");
+  });
+
+  test("should format number correctly for de-DE locale", () => {
+    intl.init({ locales, currentLocale: "de-DE" });
+    expect(intl.formatNumber(1234.567)).toBe("1.234,567");
+  });
+
+  test("should format number correctly for fr-FR locale", () => {
+    intl.init({ locales, currentLocale: "fr-FR" });
+    expect(intl.formatNumber(1234.567)).toBe("1 234,567");
+  });
+
+  test("should handle edge cases", () => {
+    intl.init({ locales, currentLocale: "en-US" });
+    expect(intl.formatNumber(NaN)).toBeNaN();
+    // Intl.NumberFormat formats Infinity as "∞" string
+    expect(intl.formatNumber(Infinity)).toBe("∞");
+    expect(intl.formatNumber(-Infinity)).toBe("-∞");
+    expect(intl.formatNumber(null)).toBeNull();
+    expect(intl.formatNumber(undefined)).toBeUndefined();
+    expect(intl.formatNumber("not a number")).toBe("not a number");
+  });
+
+  test("should handle large numbers", () => {
+    intl.init({ locales, currentLocale: "en-US" });
+    expect(intl.formatNumber(1e15)).toBe("1,000,000,000,000,000");
   });
 });

--- a/packages/react-intl-universal/test/index.test.js
+++ b/packages/react-intl-universal/test/index.test.js
@@ -382,7 +382,7 @@ describe("Exceptional cases", () => {
   test("should call intl.init before render", () => {
     const warningHandler = jest.spyOn(console, 'warn');
     innerIntl.get("SIMPLE");
-    expect(warningHandler).toHaveBeenCalledWith(`react-intl-universal locales data "null" not exists. More info: https://github.com/alibaba/react-intl-universal/issues/144#issuecomment-1345193138`);
+    expect(warningHandler).toHaveBeenCalledWith(`react-intl-universal locales data \"null\" not exists.Check if the key \"SIMPLE\" is used before it is initialized. More info: https://github.com/alibaba/react-intl-universal/issues/144#issuecomment-1345193138`);
   });
 })
 

--- a/packages/react-intl-universal/typings/index.d.ts
+++ b/packages/react-intl-universal/typings/index.d.ts
@@ -88,14 +88,29 @@ declare module "react-intl-universal" {
 
   /**
    * Formats a list of React nodes for proper internationalized formatting.
-   * @param {React.ReactNode[]} nodeList Array of React nodes to format
-   * @param {Intl.ListFormatOptions} options Intl.ListFormat options (defaults to narrow style). See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat
-   * @returns {React.ReactNode[]} Array of React nodes formatted with appropriate separators/conjunctions
+   * This method properly handles locale-specific list formatting with appropriate separators and conjunctions.
+   * 
+   * @param {React.ReactNode[]} nodeList - Array of React nodes to format. Can include strings, numbers, or React elements.
+   * @param {Intl.ListFormatOptions} options - Intl.ListFormat options for customizing the formatting style and type.
+   *   - style: 'long' | 'short' | 'narrow' - Controls the length of the separators (default: 'narrow')
+   *   - type: 'conjunction' | 'disjunction' | 'unit' - Controls the type of list pattern (default: 'conjunction')
+   *   See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat for details.
+   * @returns {React.ReactNode[]} Array of React nodes formatted with locale-appropriate separators and conjunctions.
    * 
    * @example
-   * formatList(["str1", "str2", "str2"])
-   * // Returns: ['str1', ',', 'str2', ',', 'str3'] in en-US
-   * // Returns: ['str1', '、', 'str2', '、', 'str3'] in zh-CN
+   * // For English locale (en-US):
+   * formatList(["str1", "str2", "str3"])
+   * // Returns: ['str1', ', ', 'str2', ', ', 'str3'] (with comma separators)
+   * 
+   * @example
+   * // For Chinese locale (zh-CN):
+   * formatList(["str1", "str2", "str3"])
+   * // Returns: ['str1', '、', 'str2', '、', 'str3'] (with ideographic comma separators)
+   * 
+   * @example
+   * // With custom options for disjunction (or) in English:
+   * formatList(["str1", "str2", "str3"], { type: "disjunction" })
+   * // Returns: ['str1', ', ', 'str2', ', or ', 'str3']
    */
   export function formatList(
     nodeList: React.ReactNode[],
@@ -103,25 +118,28 @@ declare module "react-intl-universal" {
   ): ReactNode[];
 
   /**
-   * Returns locale-specific parentheses format for the current language
+   * Returns locale-specific parentheses format for the current language.
+   * This method wraps the provided content with appropriate parentheses based on the current locale.
    * 
    * @description
-   * This method determines whether to use full-width parentheses (（）) or 
-   * half-width parentheses (()) based on the current locale. 
+   * This method determines whether to use full-width parentheses "（）" or 
+   * half-width parentheses "()" based on the current locale. 
    * Full-width parentheses are used for Chinese, Japanese, and Korean locales,
    * while half-width parentheses are used for all other locales.
+   * This ensures proper typographic conventions are followed for different languages.
    * 
-   * @param {React.ReactNode} node - The content to be wrapped in parentheses
+   * @param {React.ReactNode} node - The content to be wrapped in parentheses. Can be a string, number, or React element.
    * @returns {ReactNode[]} An array containing:
-   *   - Left parenthesis (（ or ( depending on locale)
+   *   - Left parenthesis "（" or "(" depending on locale
    *   - The provided node/content
-   *   - Right parenthesis (） or ) depending on locale)
+   *   - Right parenthesis "）" or ")" depending on locale
    * 
    * @example
    * // For Chinese locale (zh-CN):
    * formatParentheses("Description") 
    * // => ['（', 'Description', '）'] => Render as: ```<>（Description）</>``` in React.js
    * 
+   * @example
    * // For English locale (en-US):
    * formatParentheses("Description") 
    * // => ['(', 'Description', ')']  => Render as: ```<>(Description)</>``` in React.js
@@ -129,9 +147,64 @@ declare module "react-intl-universal" {
   export function formatParentheses(node: ReactNode): ReactNode[];
 
   /**
-   * Returns locale-specific colon character for the current language
+   * Returns locale-specific colon character for the current language.
+   * 
+   * @description
+   * This method determines whether to use a full-width colon "：" or 
+   * half-width colon ": " based on the current locale. 
+   * 
+   * @returns {string} The locale-appropriate colon character.
+   *   - Full-width colon "：" for Chinese, Japanese, and Korean locales
+   *   - Half-width colon ": " for all other locales
+   * 
+   * @example
+   * // For Chinese locale (zh-CN):
+   * getColon() 
+   * // => "："
+   * 
+   * @example
+   * // For English locale (en-US):
+   * getColon() 
+   * // => ": "
+   * 
+   * @example
+   * // Usage in a React component:
+   * <div>{intl.get("LABEL_NAME")}{intl.getColon()}{intl.get("VALUE")}</div>
    */
   export function getColon(): string;
+
+  /**
+   * Formats a number according to the current locale.
+   * 
+   * @description
+   * This method formats a number according to the current locale's conventions,
+   * including decimal separators, digit grouping, and other locale-specific formatting rules.
+   * If the input is not a valid number, it returns the original value unchanged.
+   * 
+   * @param {number} number - The number to format. Can be an integer or float.
+   * @returns {string} The formatted number.
+   * 
+   * @example
+   * // For English locale (en-US):
+   * formatNumber(1234.56)
+   * // => "1,234.56"
+   * 
+   * @example
+   * // For German locale (de-DE):
+   * formatNumber(1234.56)
+   * // => "1.234,56"
+   * 
+   * @example
+   * // For Chinese locale (zh-CN):
+   * formatNumber(1234.56)
+   * // => "1,234.56"
+   * 
+   * @example
+   * // Invalid number input:
+   * formatNumber("not-a-number")
+   * // => "not-a-number"
+   */
+  export function formatNumber(number: number): string;
 
   export interface ReactIntlUniversalOptions {
     currentLocale?: string;

--- a/packages/react-intl-universal/typings/index.d.ts
+++ b/packages/react-intl-universal/typings/index.d.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { JSX, ReactNode } from "react";
 
 declare module "react-intl-universal" {
   /**
@@ -90,7 +90,7 @@ declare module "react-intl-universal" {
    * Formats a list of React nodes for proper internationalized formatting.
    * This method properly handles locale-specific list formatting with appropriate separators and conjunctions.
    * 
-   * @param {React.ReactNode[]} nodeList - Array of React nodes to format. Can include strings, numbers, or React elements.
+   * @param {React.ReactNode[]} nodeList - Array of React nodes to format.
    * @param {Intl.ListFormatOptions} options - Intl.ListFormat options for customizing the formatting style and type.
    *   - style: 'long' | 'short' | 'narrow' - Controls the length of the separators (default: 'narrow')
    *   - type: 'conjunction' | 'disjunction' | 'unit' - Controls the type of list pattern (default: 'conjunction')
@@ -230,12 +230,18 @@ declare module "react-intl-universal" {
     getInitOptions: typeof getInitOptions;
     init: typeof init;
     load: typeof load;
+    formatList: typeof formatList;
+    formatParentheses: typeof formatParentheses;
+    getColon: typeof getColon;
+    formatNumber: typeof formatNumber;
   };
 
   export default intl;
 }
 
-declare interface String {
-  defaultMessage(msg: string | JSX.Element): string;
-  d(msg: string | JSX.Element): string;
+declare global {
+  interface String {
+    defaultMessage(msg: string | JSX.Element): string;
+    d(msg: string | JSX.Element): string;
+  }
 }

--- a/packages/react-intl-universal/typings/index.d.ts
+++ b/packages/react-intl-universal/typings/index.d.ts
@@ -1,122 +1,172 @@
+import { ReactNode } from "react";
+
 declare module "react-intl-universal" {
-    /**
-     * Change current locale
-     * @param {string} newLocale Current locale such as 'en-US'
-     */
-    export function changeCurrentLocale(newLocale: string): void;
+  /**
+   * Change current locale
+   * @param {string} newLocale Current locale such as 'en-US'
+   */
+  export function changeCurrentLocale(newLocale: string): void;
 
-    /**
-     * Helper: determine user's locale via URL, cookie, and browser's language.
-     * You may not need this API, if you have other rules to determine user's locale.
-     * @param {string} options.urlLocaleKey URL's query Key to determine locale. Example: if URL=http://localhost?lang=en-US, then set it 'lang'
-     * @param {string} options.cookieLocaleKey Cookie's Key to determine locale. Example: if cookie=lang:en-US, then set it 'lang'
-     * @param {string} options.localStorageLocaleKey LocalStorage's Key to determine locale such as 'lang'
-     * @returns {string} determined locale such as 'en-US'
-     */
-    export function determineLocale(options: ReactIntlUniversalOptions): string;
+  /**
+   * Helper: determine user's locale via URL, cookie, and browser's language.
+   * You may not need this API, if you have other rules to determine user's locale.
+   * @param {string} options.urlLocaleKey URL's query Key to determine locale. Example: if URL=http://localhost?lang=en-US, then set it 'lang'
+   * @param {string} options.cookieLocaleKey Cookie's Key to determine locale. Example: if cookie=lang:en-US, then set it 'lang'
+   * @param {string} options.localStorageLocaleKey LocalStorage's Key to determine locale such as 'lang'
+   * @returns {string} determined locale such as 'en-US'
+   */
+  export function determineLocale(options: ReactIntlUniversalOptions): string;
 
-    /**
-     * Provide React-Intl compatibility, same as getHTML(...) API.
-     */
-    export function formatHTMLMessage(messageDescriptor: ReactIntlUniversalMessageDescriptor): string;
+  /**
+   * Provide React-Intl compatibility, same as getHTML(...) API.
+   */
+  export function formatHTMLMessage(messageDescriptor: ReactIntlUniversalMessageDescriptor): string;
 
-    /**
-     * Provide React-Intl compatibility, same as getHTML(...) API.
-     */
-    export function formatHTMLMessage(messageDescriptor: ReactIntlUniversalMessageDescriptor, variables: any): string;
+  /**
+   * Provide React-Intl compatibility, same as getHTML(...) API.
+   */
+  export function formatHTMLMessage(messageDescriptor: ReactIntlUniversalMessageDescriptor, variables: any): string;
 
-    /**
-     * Provide React-Intl compatibility, same as get(...) API.
-     */
-    export function formatMessage(messageDescriptor: ReactIntlUniversalMessageDescriptor): string;
+  /**
+   * Provide React-Intl compatibility, same as get(...) API.
+   */
+  export function formatMessage(messageDescriptor: ReactIntlUniversalMessageDescriptor): string;
 
-    /**
-     * Provide React-Intl compatibility, same as get(...) API.
-     */
-    export function formatMessage(messageDescriptor: ReactIntlUniversalMessageDescriptor, variables: any): string;
+  /**
+   * Provide React-Intl compatibility, same as get(...) API.
+   */
+  export function formatMessage(messageDescriptor: ReactIntlUniversalMessageDescriptor, variables: any): string;
 
-    /**
-     * Get the formatted message by key
-     * @param {string} key The string representing key in locale data file
-     * @returns {string} message
-     */
-    export function get(key: string): string;
+  /**
+   * Get the formatted message by key
+   * @param {string} key The string representing key in locale data file
+   * @returns {string} message
+   */
+  export function get(key: string): string;
 
-    /**
-     * Get the formatted message by key
-     * @param {string} key The string representing key in locale data file
-     * @param {Object} variables Variables in message
-     * @returns {string} message
-     */
-    export function get(key: string, variables?: any): string;
+  /**
+   * Get the formatted message by key
+   * @param {string} key The string representing key in locale data file
+   * @param {Object} variables Variables in message
+   * @returns {string} message
+   */
+  export function get(key: string, variables?: any): string;
 
-    /**
-     * Get the formatted html message by key.
-     * @param {string} key The string representing key in locale data file
-     * @param {Object} variables Variables in message
-     * @returns {React.ReactElement} message
-     */
-    export function getHTML(key: string, variables?: any): string;
+  /**
+   * Get the formatted html message by key.
+   * @param {string} key The string representing key in locale data file
+   * @param {Object} variables Variables in message
+   * @returns {React.ReactElement} message
+   */
+  export function getHTML(key: string, variables?: any): string;
 
-    /**
-     * Get the inital options 
-     * @returns {Object} options includes currentLocale and locales
-     */
-    export function getInitOptions(): ReactIntlUniversalOptions;
+  /**
+   * Get the inital options 
+   * @returns {Object} options includes currentLocale and locales
+   */
+  export function getInitOptions(): ReactIntlUniversalOptions;
 
-    /**
-     * Initialize properties and load CLDR locale data according to currentLocale
-     * @param {Object} options
-     * @param {string} options.currentLocale Current locale such as 'en-US'
-     * @param {Object} options.locales App locale data like {"en-US":{"key1":"value1"},"zh-CN":{"key1":"值1"}}
-     * @param {Object} options.warningHandler Ability to accumulate missing messages using third party services like Sentry
-     * @param {string} options.fallbackLocale Fallback locale such as 'zh-CN' to use if a key is not found in the current locale
-     * @param {boolean} options.escapeHtml To escape html. Default value is true.
-     * @param {boolean} options.debug debug mode
-     * @returns {Promise}
-     */
-    export function init(options: ReactIntlUniversalOptions): Promise<void>;
+  /**
+   * Initialize properties and load CLDR locale data according to currentLocale
+   * @param {Object} options
+   * @param {string} options.currentLocale Current locale such as 'en-US'
+   * @param {Object} options.locales App locale data like {"en-US":{"key1":"value1"},"zh-CN":{"key1":"值1"}}
+   * @param {Object} options.warningHandler Ability to accumulate missing messages using third party services like Sentry
+   * @param {string} options.fallbackLocale Fallback locale such as 'zh-CN' to use if a key is not found in the current locale
+   * @param {boolean} options.escapeHtml To escape html. Default value is true.
+   * @param {boolean} options.debug debug mode
+   * @returns {Promise}
+   */
+  export function init(options: ReactIntlUniversalOptions): Promise<void>;
 
-    /**
-     * Load more locales after init
-     * @param {Object} locales App locale data 
-     */
-    export function load(locales: { [key: string]: any }): void;
+  /**
+   * Load more locales after init
+   * @param {Object} locales App locale data 
+   */
+  export function load(locales: { [key: string]: any }): void;
 
-    export interface ReactIntlUniversalOptions {
-        currentLocale?: string;
-        locales?: { [key: string]: any };
-        fallbackLocale?: string;
-        commonLocaleDataUrls?: { [key: string]: string };
-        cookieLocaleKey?: string;
-        urlLocaleKey?: string;
-        localStorageLocaleKey?: string;
-        warningHandler?: (message?: any, error?: any) => void;
-        escapeHtml?: boolean;
-        debug?: boolean;
-        dataKey?: string;
-    }
-    
-    export interface ReactIntlUniversalMessageDescriptor {
-        id: string,
-        defaultMessage?: string,
-    }
-    
-    const intl: {
-      determineLocale: typeof determineLocale;
-      formatHTMLMessage: typeof formatHTMLMessage;
-      formatMessage: typeof formatMessage;
-      get: typeof get;
-      getHTML: typeof getHTML;
-      getInitOptions: typeof getInitOptions;
-      init: typeof init;
-      load: typeof load;
-    };
 
-    export default intl;
+  /**
+   * Formats a list of React nodes for proper internationalized formatting.
+   * @param {React.ReactNode[]} nodeList Array of React nodes to format
+   * @param {Intl.ListFormatOptions} options Intl.ListFormat options (defaults to narrow style). See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/ListFormat
+   * @returns {React.ReactNode[]} Array of React nodes formatted with appropriate separators/conjunctions
+   * 
+   * @example
+   * formatList(["str1", "str2", "str2"])
+   * // Returns: ['str1', ',', 'str2', ',', 'str3'] in en-US
+   * // Returns: ['str1', '、', 'str2', '、', 'str3'] in zh-CN
+   */
+  export function formatList(
+    nodeList: React.ReactNode[],
+    options?: Intl.ListFormatOptions,
+  ): ReactNode[];
+
+  /**
+   * Returns locale-specific parentheses format for the current language
+   * 
+   * @description
+   * This method determines whether to use full-width parentheses (（）) or 
+   * half-width parentheses (()) based on the current locale. 
+   * Full-width parentheses are used for Chinese, Japanese, and Korean locales,
+   * while half-width parentheses are used for all other locales.
+   * 
+   * @param {React.ReactNode} node - The content to be wrapped in parentheses
+   * @returns {ReactNode[]} An array containing:
+   *   - Left parenthesis (（ or ( depending on locale)
+   *   - The provided node/content
+   *   - Right parenthesis (） or ) depending on locale)
+   * 
+   * @example
+   * // For Chinese locale (zh-CN):
+   * formatParentheses("Description") 
+   * // => ['（', 'Description', '）'] => Render as: ```<>（Description）</>``` in React.js
+   * 
+   * // For English locale (en-US):
+   * formatParentheses("Description") 
+   * // => ['(', 'Description', ')']  => Render as: ```<>(Description)</>``` in React.js
+   */
+  export function formatParentheses(node: ReactNode): ReactNode[];
+
+  /**
+   * Returns locale-specific colon character for the current language
+   */
+  export function getColon(): string;
+
+  export interface ReactIntlUniversalOptions {
+    currentLocale?: string;
+    locales?: { [key: string]: any };
+    fallbackLocale?: string;
+    commonLocaleDataUrls?: { [key: string]: string };
+    cookieLocaleKey?: string;
+    urlLocaleKey?: string;
+    localStorageLocaleKey?: string;
+    warningHandler?: (message?: any, error?: any) => void;
+    escapeHtml?: boolean;
+    debug?: boolean;
+    dataKey?: string;
+  }
+
+  export interface ReactIntlUniversalMessageDescriptor {
+    id: string,
+    defaultMessage?: string,
+  }
+
+  const intl: {
+    determineLocale: typeof determineLocale;
+    formatHTMLMessage: typeof formatHTMLMessage;
+    formatMessage: typeof formatMessage;
+    get: typeof get;
+    getHTML: typeof getHTML;
+    getInitOptions: typeof getInitOptions;
+    init: typeof init;
+    load: typeof load;
+  };
+
+  export default intl;
 }
 
 declare interface String {
-    defaultMessage(msg: string | JSX.Element): string;
-    d(msg: string | JSX.Element): string;
+  defaultMessage(msg: string | JSX.Element): string;
+  d(msg: string | JSX.Element): string;
 }

--- a/packages/react-intl-universal/typings/index.d.ts
+++ b/packages/react-intl-universal/typings/index.d.ts
@@ -100,17 +100,17 @@ declare module "react-intl-universal" {
    * @example
    * // For English locale (en-US):
    * formatList(["str1", "str2", "str3"])
-   * // Returns: ['str1', ', ', 'str2', ', ', 'str3'] (with comma separators)
+   * // Returns: ['str1', ', ', 'str2', ', ', 'str3'] (with comma separators) => Render as: ``str1, str2, str3``` in React.js
    * 
    * @example
    * // For Chinese locale (zh-CN):
    * formatList(["str1", "str2", "str3"])
-   * // Returns: ['str1', '、', 'str2', '、', 'str3'] (with ideographic comma separators)
+   * // Returns: ['str1', '、', 'str2', '、', 'str3'] (with ideographic comma separators) => Render as: ``str1、str2、str3``` in React.js
    * 
    * @example
    * // With custom options for disjunction (or) in English:
    * formatList(["str1", "str2", "str3"], { type: "disjunction" })
-   * // Returns: ['str1', ', ', 'str2', ', or ', 'str3']
+   * // Returns: ['str1', ', ', 'str2', ', or ', 'str3']  => Render as: ``str1, str2, or str3``` in React.js
    */
   export function formatList(
     nodeList: React.ReactNode[],
@@ -186,23 +186,19 @@ declare module "react-intl-universal" {
    * 
    * @example
    * // For English locale (en-US):
-   * formatNumber(1234.56)
-   * // => "1,234.56"
+   * formatNumber(1234.56) // => "1,234.56"
    * 
    * @example
    * // For German locale (de-DE):
-   * formatNumber(1234.56)
-   * // => "1.234,56"
+   * formatNumber(1234.56) // => "1.234,56"
    * 
    * @example
    * // For Chinese locale (zh-CN):
-   * formatNumber(1234.56)
-   * // => "1,234.56"
+   * formatNumber(1234.56) // => "1,234.56"
    * 
    * @example
    * // Invalid number input:
-   * formatNumber("not-a-number")
-   * // => "not-a-number"
+   * formatNumber("not-a-number") // => "not-a-number"
    */
   export function formatNumber(number: number): string;
 


### PR DESCRIPTION
This PR introduces four new APIs to enhance the internationalization capabilities of react-intl-universal:

1. `formatList` - Formats a list of React nodes with locale-appropriate separators
2. `formatParentheses` - Returns locale-specific parentheses format
3. `getColon` - Returns locale-specific colon character
4. `formatNumber` - Formats numbers according to the current locale

These new APIs provide more granular control over localization formatting, allowing developers to create more culturally appropriate UIs with less manual work.
